### PR TITLE
Prioritized Log Forwarding from the Agent

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -59,6 +59,7 @@ module NewRelic
     require 'new_relic/agent/logging'
     require 'new_relic/agent/distributed_tracing'
     require 'new_relic/agent/attribute_processing'
+    require 'new_relic/agent/linking_metadata'
 
     require 'new_relic/agent/instrumentation/controller_instrumentation'
 
@@ -726,20 +727,8 @@ module NewRelic
     # @api public
     def linking_metadata
       metadata = Hash.new
-      metadata[ENTITY_NAME_KEY] = config[:app_name][0]
-      metadata[ENTITY_TYPE_KEY] = ENTITY_TYPE
-      metadata[HOSTNAME_KEY] = Hostname.get
-
-      if entity_guid = config[:entity_guid]
-        metadata[ENTITY_GUID_KEY] = entity_guid
-      end
-
-      if trace_id = Tracer.current_trace_id
-        metadata[TRACE_ID_KEY] = trace_id
-      end
-      if span_id = Tracer.current_span_id
-        metadata[SPAN_ID_KEY] = span_id
-      end
+      LinkingMetadata.append_service_linking_metadata(metadata)
+      LinkingMetadata.append_trace_linking_metadata(metadata)
       metadata
     end
 

--- a/lib/new_relic/agent/agent.rb
+++ b/lib/new_relic/agent/agent.rb
@@ -25,6 +25,7 @@ require 'new_relic/agent/monitors'
 require 'new_relic/agent/transaction_event_recorder'
 require 'new_relic/agent/custom_event_aggregator'
 require 'new_relic/agent/span_event_aggregator'
+require 'new_relic/agent/log_event_aggregator'
 require 'new_relic/agent/sampler_collection'
 require 'new_relic/agent/javascript_instrumentor'
 require 'new_relic/agent/vm/monotonic_gc_profiler'
@@ -73,6 +74,7 @@ module NewRelic
         @transaction_event_recorder = TransactionEventRecorder.new @events
         @custom_event_aggregator = CustomEventAggregator.new @events
         @span_event_aggregator = SpanEventAggregator.new @events
+        @log_event_aggregator = LogEventAggregator.new @events
 
         @connect_state = :pending
         @connect_attempts = 0
@@ -146,6 +148,7 @@ module NewRelic
         attr_reader :monotonic_gc_profiler
         attr_reader :custom_event_aggregator
         attr_reader :span_event_aggregator
+        attr_reader :log_event_aggregator
         attr_reader :transaction_event_recorder
         attr_reader :attribute_filter
         attr_reader :adaptive_sampler
@@ -559,6 +562,7 @@ module NewRelic
           @transaction_event_recorder.drop_buffered_data
           @custom_event_aggregator.reset!
           @span_event_aggregator.reset!
+          @log_event_aggregator.reset!
           @sql_sampler.reset!
 
           if Agent.config[:clear_transaction_state_after_fork]

--- a/lib/new_relic/agent/agent_logger.rb
+++ b/lib/new_relic/agent/agent_logger.rb
@@ -6,6 +6,7 @@ require 'thread'
 require 'logger'
 require 'new_relic/agent/hostname'
 require 'new_relic/agent/log_once'
+require 'new_relic/agent/instrumentation/logger/instrumentation'
 
 module NewRelic
   module Agent
@@ -18,6 +19,7 @@ module NewRelic
         create_log(root, override_logger)
         set_log_level!
         set_log_format!
+        disable_log_instrumentation!
 
         gather_startup_logs
       end
@@ -167,6 +169,11 @@ module NewRelic
         @log.formatter = Proc.new do |severity, timestamp, progname, msg|
           "#{@prefix}[#{timestamp.strftime("%F %H:%M:%S %z")} #{@hostname} (#{$$})] #{severity} : #{msg}\n"
         end
+      end
+
+      # Don't allow agent logs into agent log forwarding for now
+      def disable_log_instrumentation!
+        NewRelic::Agent::Instrumentation::Logger.mark_skip_instrumenting(@log)
       end
 
       def gather_startup_logs

--- a/lib/new_relic/agent/audit_logger.rb
+++ b/lib/new_relic/agent/audit_logger.rb
@@ -5,6 +5,7 @@
 require 'logger'
 require 'fileutils'
 require 'new_relic/agent/hostname'
+require 'new_relic/agent/instrumentation/logger/instrumentation'
 
 module NewRelic
   module Agent
@@ -69,6 +70,9 @@ module NewRelic
         else
           @log = NewRelic::Agent::NullLogger.new
         end
+
+        # Never have agent log forwarding capture audits
+        NewRelic::Agent::Instrumentation::Logger.mark_skip_instrumenting(@log)
 
         @log.formatter = create_log_formatter
       end

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1839,6 +1839,21 @@ module NewRelic
           :description => 'Specify a maximum number of custom Insights events to buffer in memory at a time.',
           :dynamic_name => true
         },
+        :'log_sending.enabled' => {
+          :default      => true,
+          :public       => true,
+          :type         => Boolean,
+          :allowed_from_server => true,
+          :description  => 'If `true`, the agent captures log records emitted by your application.'
+        },
+        :'log_sending.max_samples_stored' => {
+          :default      => 1000,
+          :public       => true,
+          :type         => Integer,
+          :allowed_from_server => true,
+          :description  => 'Specify a maximum number of log records to buffer in memory at a time.',
+          :dynamic_name => true
+        },
         :disable_grape_instrumentation => {
           :default => false,
           :public => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1839,15 +1839,15 @@ module NewRelic
           :description => 'Specify a maximum number of custom Insights events to buffer in memory at a time.',
           :dynamic_name => true
         },
-        :'log_sending.enabled' => {
+        :'application_logging.forwarding.enabled' => {
           :default      => true,
           :public       => true,
           :type         => Boolean,
           :allowed_from_server => true,
           :description  => 'If `true`, the agent captures log records emitted by your application.'
         },
-        :'log_sending.max_samples_stored' => {
-          :default      => 1000,
+        :'application_logging.forwarding.max_samples_stored' => {
+          :default      => 2000,
           :public       => true,
           :type         => Integer,
           :allowed_from_server => true,

--- a/lib/new_relic/agent/instrumentation/logger.rb
+++ b/lib/new_relic/agent/instrumentation/logger.rb
@@ -21,5 +21,7 @@ DependencyDetection.defer do
     else
       chain_instrument NewRelic::Agent::Instrumentation::Logger
     end
+
+    ::NewRelic::Agent.increment_metric("Supportability/Logging/enabled/Ruby/Logger")
   end
 end

--- a/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
@@ -10,6 +10,17 @@ module NewRelic
           defined?(@skip_instrumenting) && @skip_instrumenting
         end
 
+        # We support setting this on loggers which might not have
+        # instrumentation installed yet. This lets us disable in AgentLogger
+        # and AuditLogger without them having to know the inner details.
+        def self.mark_skip_instrumenting(logger)
+          logger.instance_variable_set(:@skip_instrumenting, true)
+        end
+
+        def self.clear_skip_instrumenting(logger)
+          logger.instance_variable_set(:@skip_instrumenting, false)
+        end
+
         def mark_skip_instrumenting
           @skip_instrumenting = true
         end

--- a/lib/new_relic/agent/linking_metadata.rb
+++ b/lib/new_relic/agent/linking_metadata.rb
@@ -1,0 +1,45 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Agent
+    #
+    # This module contains helper methods related to gathering linking
+    # metadata for use with logs in context.
+    module LinkingMetadata
+      extend self
+
+      def append_service_linking_metadata metadata
+        raise ArgumentError, "Missing argument `metadata`" if metadata.nil?
+
+        config = ::NewRelic::Agent.config
+
+        metadata[ENTITY_NAME_KEY] = config[:app_name][0]
+        metadata[ENTITY_TYPE_KEY] = ENTITY_TYPE
+        metadata[HOSTNAME_KEY] = Hostname.get
+
+        if entity_guid = config[:entity_guid]
+          metadata[ENTITY_GUID_KEY] = entity_guid
+        end
+
+        metadata
+      end
+
+      def append_trace_linking_metadata metadata
+        raise ArgumentError, "Missing argument `metadata`" if metadata.nil?
+
+        if trace_id = Tracer.current_trace_id
+          metadata[TRACE_ID_KEY] = trace_id
+        end
+
+        if span_id = Tracer.current_span_id
+          metadata[SPAN_ID_KEY] = span_id
+        end
+
+        metadata
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -21,7 +21,7 @@ module NewRelic
       # TODO use the right value when the collector starts reporting it
       capacity_key :'custom_insights_events.max_samples_stored'
       #capacity_key :'log_sending.max_samples_stored'
-      enabled_key :'log_sending.enabled'
+      enabled_key :'application_logging.forwarding.enabled'
       buffer_class PrioritySampledBuffer
 
       def initialize(events)

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -1,0 +1,185 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require 'new_relic/agent/event_aggregator'
+require 'new_relic/agent/log_priority'
+
+module NewRelic
+  module Agent
+    class LogEventAggregator < EventAggregator
+
+      # Common keys
+      PLUGIN_TYPE_KEY = "plugin.type".freeze
+      PLUGIN_TYPE = "nr-ruby_agent".freeze
+
+      # Per-message keys
+      LEVEL_KEY = "level".freeze
+      MESSAGE_KEY = "message".freeze
+      TIMESTAMP_KEY = "timestamp".freeze
+
+      # Metric keys
+      LINES = "Logging/lines".freeze
+
+      named :LogEventAggregator
+      # TODO use the right value when the collector starts reporting it
+      capacity_key :'custom_insights_events.max_samples_stored'
+      #capacity_key :'log_sending.max_samples_stored'
+      enabled_key :'log_sending.enabled'
+      buffer_class PrioritySampledBuffer
+
+      def initialize(events)
+        super(events)
+        @counter_lock = Mutex.new
+        @seen = 0
+        @seen_by_severity = Hash.new(0)
+      end
+
+      def capacity
+        @buffer.capacity
+      end
+
+      def record(formatted_message, severity)
+        @counter_lock.synchronize do
+          @seen += 1
+          @seen_by_severity[severity] += 1
+        end
+
+        return unless enabled?
+
+        priority = LogPriority.priority_for(severity)
+
+        txn = NewRelic::Agent::Transaction.tl_current
+        if txn
+          return txn.add_log_event(create_event(priority, formatted_message, severity))
+        else
+          return @lock.synchronize do
+            @buffer.append(priority: priority) do
+              create_event(priority, formatted_message, severity)
+            end
+          end
+        end
+      rescue
+        nil
+      end
+
+      def record_batch txn, logs
+        # Capture our finalized priority
+        logs.each do |log|
+          log.first["priority"] = LogPriority.priority_for(log.last["level"], txn)
+        end
+
+        @lock.synchronize do
+          logs.each do |log|
+            @buffer.append(event: log)
+          end
+        end
+      end
+
+      def create_event priority, formatted_message, severity
+        event = LinkingMetadata.append_trace_linking_metadata({
+          LEVEL_KEY => severity,
+          MESSAGE_KEY => formatted_message,
+          TIMESTAMP_KEY => Process.clock_gettime(Process::CLOCK_REALTIME)
+        })
+
+        [
+          {
+            PrioritySampledBuffer::PRIORITY_KEY => priority
+          },
+          event
+        ]
+      end
+
+      # Because our transmission format (MELT) is different than historical
+      # agent payloads, extract the munging here to keep the service focus
+      #
+      # We have to keep the aggregated payloads in a separate shape, though, to
+      # work with the priority sampling buffers
+      def self.payload_to_melt_format(data)
+        metadata, items = data
+        payload = [{
+          common: { attributes: metadata[:linking] },
+          logs: items.map(&:last)
+        }]
+
+        return [payload, items.size]
+      end
+
+      def harvest!
+        record_customer_metrics()
+        super
+      end
+
+      def reset!
+        @counter_lock.synchronize do
+          @seen = 0
+          @seen_by_severity.clear
+        end
+        super
+      end
+
+      private
+
+      # Slightly awkward, but we want the base harvest but without
+      # this method altering the metadata we gather...
+      def reservoir_metadata metadata
+        metadata
+      end
+
+      def register_capacity_callback
+        NewRelic::Agent.config.register_callback(self.class.capacity_key) do |max_samples|
+          NewRelic::Agent.logger.debug "#{self.class.named} max_samples set to #{max_samples}"
+          @lock.synchronize do
+            @buffer.capacity = max_samples
+          end
+        end
+      end
+
+      def after_harvest metadata
+        linking = { PLUGIN_TYPE_KEY => PLUGIN_TYPE }
+        LinkingMetadata.append_service_linking_metadata(linking)
+        metadata[:linking] = linking
+
+        dropped_count = metadata[:seen] - metadata[:captured]
+        note_dropped_events(metadata[:seen], dropped_count)
+        record_supportability_metrics(metadata[:seen], metadata[:captured], dropped_count)
+      end
+
+      # To avoid paying the cost of metric recording on every line, we hold
+      # these until harvest before recording them
+      def record_customer_metrics
+        @counter_lock.synchronize do
+          return unless @seen > 0
+
+          NewRelic::Agent.increment_metric(LINES, @seen)
+          @seen_by_severity.each do |(severity, count)|
+            NewRelic::Agent.increment_metric(line_metric_name_by_severity(severity), count)
+          end
+
+          @seen = 0
+          @seen_by_severity.clear
+        end
+      end
+
+      def line_metric_name_by_severity(severity)
+        @line_metrics ||= {}
+        @line_metrics[severity] ||= "Logging/lines/#{severity}".freeze
+      end
+
+      def note_dropped_events total_count, dropped_count
+        if dropped_count > 0
+          NewRelic::Agent.logger.warn("Dropped #{dropped_count} log events out of #{total_count}.")
+        end
+      end
+
+      def record_supportability_metrics total_count, captured_count, dropped_count
+        return unless total_count > 0
+
+        NewRelic::Agent.increment_metric("Supportability/Logging/Customer/Seen", total_count)
+        NewRelic::Agent.increment_metric("Supportability/Logging/Customer/Sent", captured_count)
+        NewRelic::Agent.increment_metric("Supportability/Logging/Customer/Dropped", dropped_count)
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -90,7 +90,7 @@ module NewRelic
         event = LinkingMetadata.append_trace_linking_metadata({
           LEVEL_KEY => severity,
           MESSAGE_KEY => formatted_message,
-          TIMESTAMP_KEY => Process.clock_gettime(Process::CLOCK_REALTIME)
+          TIMESTAMP_KEY => Process.clock_gettime(Process::CLOCK_REALTIME) * 1000
         })
 
         [

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -117,6 +117,11 @@ module NewRelic
       def self.payload_to_melt_format(data)
         common_attributes = LinkingMetadata.append_service_linking_metadata({})
 
+        # To save on unnecessary data transmission, trim the name and type
+        # that were sent by classic logs-in-context
+        common_attributes.delete(ENTITY_NAME_KEY)
+        common_attributes.delete(ENTITY_TYPE_KEY)
+
         _, items = data
         payload = [{
           common: { attributes: common_attributes },

--- a/lib/new_relic/agent/log_priority.rb
+++ b/lib/new_relic/agent/log_priority.rb
@@ -10,21 +10,10 @@ module NewRelic
     module LogPriority
       extend self
 
-      SEVERITIES = Logger::Severity.constants.inject({}) do |memo, sev|
-        memo[sev.to_s] = Logger::Severity.const_get(sev)
-        memo
-      end
+      def priority_for(txn)
+        return txn.priority if txn
 
-      TRANSACTION_BONUS = 10
-      TRANSACTION_ERROR_BONUS = 10
-      TRANSACTION_SAMPLE_BONUS = 100
-
-      def priority_for(severity, txn = nil)
-        priority = SEVERITIES[severity.to_s] || 0
-        priority += TRANSACTION_BONUS if txn
-        priority += TRANSACTION_ERROR_BONUS if txn && txn.payload && txn.payload[:error]
-        priority += TRANSACTION_SAMPLE_BONUS if txn && txn.sampled?
-        priority
+        rand.round(NewRelic::PRIORITY_PRECISION)
       end
     end
   end

--- a/lib/new_relic/agent/log_priority.rb
+++ b/lib/new_relic/agent/log_priority.rb
@@ -1,0 +1,31 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require 'new_relic/agent/event_aggregator'
+
+# Stateless calculation of priority for a given log event
+module NewRelic
+  module Agent
+    module LogPriority
+      extend self
+
+      SEVERITIES = Logger::Severity.constants.inject({}) do |memo, sev|
+        memo[sev.to_s] = Logger::Severity.const_get(sev)
+        memo
+      end
+
+      TRANSACTION_BONUS = 10
+      TRANSACTION_ERROR_BONUS = 10
+      TRANSACTION_SAMPLE_BONUS = 100
+
+      def priority_for(severity, txn = nil)
+        priority = SEVERITIES[severity.to_s] || 0
+        priority += TRANSACTION_BONUS if txn
+        priority += TRANSACTION_ERROR_BONUS if txn && txn.payload && txn.payload[:error]
+        priority += TRANSACTION_SAMPLE_BONUS if txn && txn.sampled?
+        priority
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -179,16 +179,18 @@ module NewRelic
 
       def error_event_data(data)
         metadata, items = data
-        invoke_remote(:error_event_data, [@agent_id, *data], :item_count => items.size)
+        response = invoke_remote(:error_event_data, [@agent_id, *data], :item_count => items.size)
         NewRelic::Agent.record_metric("Supportability/Events/TransactionError/Sent", :count => items.size)
         NewRelic::Agent.record_metric("Supportability/Events/TransactionError/Seen", :count => metadata[:events_seen])
+        response
       end
 
       def span_event_data(data)
         metadata, items = data
-        invoke_remote(:span_event_data, [@agent_id, *data], :item_count => items.size)
+        response = invoke_remote(:span_event_data, [@agent_id, *data], :item_count => items.size)
         NewRelic::Agent.record_metric("Supportability/Events/SpanEvents/Sent", :count => items.size)
         NewRelic::Agent.record_metric("Supportability/Events/SpanEvents/Seen", :count => metadata[:events_seen])
+        response
       end
 
       # We do not compress if content is smaller than 64kb.  There are

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -177,6 +177,11 @@ module NewRelic
           :item_count => items.size)
       end
 
+      def log_event_data(data)
+        payload, size = LogEventAggregator.payload_to_melt_format(data)
+        invoke_remote(:log_event_data, payload, :item_count => size)
+      end
+
       def error_event_data(data)
         metadata, items = data
         response = invoke_remote(:error_event_data, [@agent_id, *data], :item_count => items.size)

--- a/lib/new_relic/agent/pipe_service.rb
+++ b/lib/new_relic/agent/pipe_service.rb
@@ -61,6 +61,10 @@ module NewRelic
         write_to_pipe(:sql_trace_data, sql) if sql
       end
 
+      def log_event_data(logs)
+        write_to_pipe(:log_event_data, logs) if logs
+      end
+
       def shutdown
         @pipe.close if @pipe
       end

--- a/test/multiverse/suites/agent_only/audit_log_test.rb
+++ b/test/multiverse/suites/agent_only/audit_log_test.rb
@@ -26,6 +26,7 @@ class AuditLogTest < Minitest::Test
     run_agent do
       perform_actions
       assert_equal('', audit_log_contents)
+      assert_empty($collector.calls_for(:log_event_data))
     end
   end
 
@@ -33,6 +34,7 @@ class AuditLogTest < Minitest::Test
     run_agent(:'audit_log.enabled' => false) do
       perform_actions
       assert_equal('', audit_log_contents)
+      assert_empty($collector.calls_for(:log_event_data))
     end
   end
 
@@ -42,6 +44,7 @@ class AuditLogTest < Minitest::Test
       $collector.agent_data.each do |req|
         assert_audit_log_contains_object(audit_log_contents, req.body)
       end
+      assert_empty($collector.calls_for(:log_event_data))
     end
   end
 
@@ -53,5 +56,8 @@ class AuditLogTest < Minitest::Test
       nil, 1.5, state)
     NewRelic::Agent.instance.sql_sampler.on_finishing_transaction(state, 'txn')
     NewRelic::Agent.instance.send(:harvest_and_send_slowest_sql)
+
+    # We also trigger log event data sending because we shouldn't see any
+    NewRelic::Agent.instance.send(:harvest_and_send_log_event_data)
   end
 end

--- a/test/multiverse/suites/agent_only/log_events_test.rb
+++ b/test/multiverse/suites/agent_only/log_events_test.rb
@@ -1,0 +1,66 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+class LogEventsTest < Minitest::Test
+  include MultiverseHelpers
+
+  setup_and_teardown_agent
+
+  def test_log_event_data_sent_in_transaction
+    trace_id = nil
+    span_id = nil
+    in_transaction do |txn|
+      NewRelic::Agent.agent.log_event_aggregator.reset!
+      NewRelic::Agent.agent.log_event_aggregator.record("Deadly", "FATAL")
+      trace_id = NewRelic::Agent::Tracer.current_trace_id
+      span_id = NewRelic::Agent::Tracer.current_span_id
+    end
+
+    NewRelic::Agent.agent.send(:harvest_and_send_log_event_data)
+
+    last_log = last_log_event
+    assert_equal "Deadly", last_log["message"]
+    assert_equal "FATAL", last_log["level"]
+    assert_equal trace_id, last_log["trace.id"]
+    assert_equal span_id, last_log["span.id"]
+
+    common = last_logs_common
+    assert_equal "test", common["attributes"]["entity.name"]
+    assert_equal "SERVICE", common["attributes"]["entity.type"]
+    assert_equal NewRelic::Agent::Hostname.get, common["attributes"]["hostname"]
+  end
+
+  def test_log_event_data_sent_no_transaction
+    NewRelic::Agent.agent.log_event_aggregator.reset!
+    NewRelic::Agent.agent.log_event_aggregator.record("Deadly", "FATAL")
+
+    NewRelic::Agent.agent.send(:harvest_and_send_log_event_data)
+
+    last_log = last_log_event
+    assert_equal "Deadly", last_log["message"]
+    assert_equal "FATAL", last_log["level"]
+    assert_equal nil, last_log["trace.id"]
+    assert_equal nil, last_log["span.id"]
+
+    common = last_logs_common
+    assert_equal "test", common["attributes"]["entity.name"]
+    assert_equal "SERVICE", common["attributes"]["entity.type"]
+    assert_equal NewRelic::Agent::Hostname.get, common["attributes"]["hostname"]
+  end
+
+  def last_log_event
+    post = last_log_post
+    assert_equal(1, post.logs.size)
+    post.logs.last
+  end
+
+  def last_logs_common
+    post = last_log_post
+    post.common
+  end
+
+  def last_log_post
+    $collector.calls_for(:log_event_data).first
+  end
+end

--- a/test/multiverse/suites/agent_only/log_events_test.rb
+++ b/test/multiverse/suites/agent_only/log_events_test.rb
@@ -26,8 +26,8 @@ class LogEventsTest < Minitest::Test
     assert_equal span_id, last_log["span.id"]
 
     common = last_logs_common
-    assert_equal "test", common["attributes"]["entity.name"]
-    assert_equal "SERVICE", common["attributes"]["entity.type"]
+    assert_equal nil, common["attributes"]["entity.name"]
+    assert_equal nil, common["attributes"]["entity.type"]
     assert_equal NewRelic::Agent::Hostname.get, common["attributes"]["hostname"]
   end
 
@@ -44,8 +44,8 @@ class LogEventsTest < Minitest::Test
     assert_equal nil, last_log["span.id"]
 
     common = last_logs_common
-    assert_equal "test", common["attributes"]["entity.name"]
-    assert_equal "SERVICE", common["attributes"]["entity.type"]
+    assert_equal nil, common["attributes"]["entity.name"]
+    assert_equal nil, common["attributes"]["entity.type"]
     assert_equal NewRelic::Agent::Hostname.get, common["attributes"]["hostname"]
   end
 

--- a/test/multiverse/suites/high_security/high_security_test.rb
+++ b/test/multiverse/suites/high_security/high_security_test.rb
@@ -220,4 +220,12 @@ class HighSecurityTest < Minitest::Test
       refute_nil intrinsic_attributes['path_hash']
     end
   end
+
+  def test_blocks_log_capture
+    Logger.new(StringIO.new()).fatal("Ooops")
+
+    run_harvest
+
+    assert_empty $collector.calls_for("log_event_data")
+  end
 end

--- a/test/multiverse/suites/logger/config/newrelic.yml
+++ b/test/multiverse/suites/logger/config/newrelic.yml
@@ -16,3 +16,6 @@ development:
     stack_trace_threshold: 0.5
     transaction_threshold: 1.0
   capture_params: false
+  application_logging:
+    forwarding:
+      enabled: true

--- a/test/multiverse/suites/logger/logger_instrumentation_test.rb
+++ b/test/multiverse/suites/logger/logger_instrumentation_test.rb
@@ -155,9 +155,9 @@ class LoggerInstrumentationTest < Minitest::Test
     assert_metrics_recorded_exclusive({
       "Logging/lines" => {:call_count => count},
       "Logging/lines/#{level}" => {:call_count => count},
-      "Supportability/Logging/Customer/Seen" => {},
-      "Supportability/Logging/Customer/Sent" => {},
-      "Supportability/Logging/Customer/Dropped" => {},
+      "Logging/Forwarding/Dropped" => {},
+      "Supportability/Logging/Forwarding/Seen" => {},
+      "Supportability/Logging/Forwarding/Sent" => {},
     },
     :ignore_filter => %r{^Supportability/API/})
   end

--- a/test/multiverse/suites/logger/logger_instrumentation_test.rb
+++ b/test/multiverse/suites/logger/logger_instrumentation_test.rb
@@ -15,10 +15,12 @@ class LoggerInstrumentationTest < Minitest::Test
     end
 
     NewRelic::Agent.instance.stats_engine.reset!
+    NewRelic::Agent.instance.log_event_aggregator.reset!
   end
 
   def teardown
     NewRelic::Agent.instance.stats_engine.reset!
+    NewRelic::Agent.instance.log_event_aggregator.reset!
   end
 
   LEVELS = [
@@ -35,7 +37,7 @@ class LoggerInstrumentationTest < Minitest::Test
       @logger.send(name, "A message")
       assert_equal(1, @written.string.lines.count)
       assert_match(/#{name.upcase}.*A message/, @written.string)
-      assert_logging_metrics(name.upcase)
+      assert_logging_instrumentation(name.upcase)
     end
 
     define_method("test_records_multiple_calls_#{name}") do
@@ -45,7 +47,7 @@ class LoggerInstrumentationTest < Minitest::Test
       assert_equal(2, @written.string.lines.count)
       assert_match(/#{name.upcase}.*A message/, @written.string)
       assert_match(/#{name.upcase}.*Another/, @written.string)
-      assert_logging_metrics(name.upcase, 2)
+      assert_logging_instrumentation(name.upcase, 2)
     end
 
     # logger#debug(Object.new)
@@ -53,7 +55,7 @@ class LoggerInstrumentationTest < Minitest::Test
       @logger.send(name, Object.new)
       assert_equal(1, @written.string.lines.count)
       assert_match(/#{name.upcase}.*<Object.*>/, @written.string)
-      assert_logging_metrics(name.upcase)
+      assert_logging_instrumentation(name.upcase)
     end
 
     # logger#debug { "message" }
@@ -64,7 +66,7 @@ class LoggerInstrumentationTest < Minitest::Test
 
       assert_equal(1, @written.string.lines.count)
       assert_match(/#{name.upcase}.*A message/, @written.string)
-      assert_logging_metrics(name.upcase)
+      assert_logging_instrumentation(name.upcase)
     end
 
     # logger#log(Logger::DEBUG, "message")
@@ -72,7 +74,7 @@ class LoggerInstrumentationTest < Minitest::Test
       @logger.log(level, "A message")
       assert_equal(1, @written.string.lines.count)
       assert_match(/#{name.upcase}.*A message/, @written.string)
-      assert_logging_metrics(name.upcase)
+      assert_logging_instrumentation(name.upcase)
     end
 
     # logger#log(Logger::DEBUG} { "message" }
@@ -80,7 +82,7 @@ class LoggerInstrumentationTest < Minitest::Test
       @logger.log(level) { "A message" }
       assert_equal(1, @written.string.lines.count)
       assert_match(/#{name.upcase}.*A message/, @written.string)
-      assert_logging_metrics(name.upcase)
+      assert_logging_instrumentation(name.upcase)
     end
 
     # logger#log(Logger::DEBUG, "message", "progname")
@@ -88,7 +90,7 @@ class LoggerInstrumentationTest < Minitest::Test
       @logger.log(level, "A message", "progname")
       assert_equal(1, @written.string.lines.count)
       assert_match(/#{name.upcase}.*progname.*A message/, @written.string)
-      assert_logging_metrics(name.upcase)
+      assert_logging_instrumentation(name.upcase)
     end
   end
 
@@ -96,35 +98,35 @@ class LoggerInstrumentationTest < Minitest::Test
     @logger.level = ::Logger::INFO
     @logger.debug("Won't see this")
     assert_equal(0, @written.string.lines.count)
-    refute_any_logging_metrics()
+    refute_any_logging_instrumentation()
   end
 
   def test_unknown
     @logger.unknown("A message")
     assert_equal(1, @written.string.lines.count)
     assert_match(/ANY.*A message/, @written.string)
-    assert_logging_metrics("ANY")
+    assert_logging_instrumentation("ANY")
   end
 
   def test_really_high_level
     @logger.log(1_000_000, "A message")
     assert_equal(1, @written.string.lines.count)
     assert_match(/ANY.*A message/, @written.string)
-    assert_logging_metrics("ANY")
+    assert_logging_instrumentation("ANY")
   end
 
   def test_really_high_level_with_progname
     @logger.log(1_000_000, "A message", "progname")
     assert_equal(1, @written.string.lines.count)
     assert_match(/ANY.*progname.*A message/, @written.string)
-    assert_logging_metrics("ANY")
+    assert_logging_instrumentation("ANY")
   end
 
   def test_nil_severity
     @logger.log(nil, "A message", "progname")
     assert_equal(1, @written.string.lines.count)
     assert_match(/ANY.*progname.*A message/, @written.string)
-    assert_logging_metrics("ANY")
+    assert_logging_instrumentation("ANY")
   end
 
   def test_skips_when_set
@@ -133,21 +135,30 @@ class LoggerInstrumentationTest < Minitest::Test
 
     assert_equal(1, @written.string.lines.count)
     assert_match(/ANY.*progname.*A message/, @written.string)
-    refute_any_logging_metrics()
+    refute_any_logging_instrumentation()
   end
 
-  def refute_any_logging_metrics
+  def refute_any_logging_instrumentation
+    _, logs = NewRelic::Agent.agent.log_event_aggregator.harvest!
+    assert_empty logs
+
     assert_metrics_recorded_exclusive([])
   end
 
-  def assert_logging_metrics(label, count = 1)
+  def assert_logging_instrumentation(level, count = 1)
+    # We count on Logger calls but actually write metrics on harvest to
+    # minimize impact in the hot path
+    _, logs = NewRelic::Agent.agent.log_event_aggregator.harvest!
+    logs_at_level = logs.select { |log| log.last["level"] == level }
+    assert_equal count, logs_at_level.count
+
     assert_metrics_recorded_exclusive({
       "Logging/lines" => {:call_count => count},
-      "Logging/lines/#{label}" => {:call_count => count},
-      "Logging/size" => {},
-      "Logging/size/#{label}" => {},
-      "Supportability/API/increment_metric" => {},
-      "Supportability/API/record_metric" => {}
-    })
+      "Logging/lines/#{level}" => {:call_count => count},
+      "Supportability/Logging/Customer/Seen" => {},
+      "Supportability/Logging/Customer/Sent" => {},
+      "Supportability/Logging/Customer/Dropped" => {},
+    },
+    :ignore_filter => %r{^Supportability/API/})
   end
 end

--- a/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
+++ b/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
@@ -343,15 +343,10 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
               "Datastore/all" => {:call_count => 3},
               "Supportability/API/drop_buffered_data" => {:call_count => 1},
               "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all" => {:call_count => 1},
-              "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb" => {:call_count => 1},
-              "Logging/lines" => {},
-              "Logging/lines/DEBUG" => {},
-              "Logging/size" => {},
-              "Logging/size/DEBUG" => {},
-              "Supportability/API/increment_metric" => {},
-              "Supportability/API/record_metric" => {}
+              "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb" => {:call_count => 1}
             }
-            assert_metrics_recorded_exclusive expected
+            assert_metrics_recorded_exclusive(expected,
+                                              :ignore_filter => /^(Logging)/)
           end
 
           def test_batched_queries_have_node_per_query

--- a/test/multiverse/suites/rack/nested_non_rack_app_test.rb
+++ b/test/multiverse/suites/rack/nested_non_rack_app_test.rb
@@ -60,15 +60,9 @@ if NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported?
           "Nested/Controller/Rack/NestedNonRackAppTest::RailsishApp/call",
           ["Nested/Controller/Rack/NestedNonRackAppTest::RailsishApp/call", "Controller/NestedNonRackAppTest::RailsishApp/inner"],
           'DurationByCaller/Unknown/Unknown/Unknown/HTTP/all',
-          'DurationByCaller/Unknown/Unknown/Unknown/HTTP/allWeb',
-          'Logging/lines',
-          'Logging/lines/INFO',
-          'Logging/lines/WARN',
-          'Logging/size',
-          'Logging/size/INFO',
-          'Logging/size/WARN'
+          'DurationByCaller/Unknown/Unknown/Unknown/HTTP/allWeb'
         ],
-        :ignore_filter => /^Supportability/
+        :ignore_filter => /^(Supportability|Logging)/
       )
     end
   end

--- a/test/multiverse/suites/rack/rack_auto_instrumentation_test.rb
+++ b/test/multiverse/suites/rack/rack_auto_instrumentation_test.rb
@@ -147,15 +147,9 @@ if NewRelic::Agent::Instrumentation::RackHelpers.version_supported? && defined? 
           ["Middleware/Rack/MiddlewareOne/call", "Controller/Middleware/Rack/MiddlewareTwo/call"],
           ["Middleware/Rack/MiddlewareTwo/call", "Controller/Middleware/Rack/MiddlewareTwo/call"],
           'DurationByCaller/Unknown/Unknown/Unknown/HTTP/all',
-          'DurationByCaller/Unknown/Unknown/Unknown/HTTP/allWeb',
-          'Logging/lines',
-          'Logging/lines/INFO',
-          'Logging/lines/WARN',
-          'Logging/size',
-          'Logging/size/INFO',
-          'Logging/size/WARN'
+          'DurationByCaller/Unknown/Unknown/Unknown/HTTP/allWeb'
         ],
-        :ignore_filter => /^Supportability/
+        :ignore_filter => /^(Supportability|Logging)/
       )
     end
 

--- a/test/multiverse/suites/sinatra/sinatra_metric_explosion_test.rb
+++ b/test/multiverse/suites/sinatra/sinatra_metric_explosion_test.rb
@@ -88,7 +88,7 @@ class SinatraMetricExplosionTest < Minitest::Test
       name_beginnings_to_ignore.any? { |name| metric.start_with?(name) }
     end
 
-    assert_equal 17, metric_names.size, "Explosion detected in: #{metric_names.inspect}"
+    assert_equal 11, metric_names.size, "Explosion detected in: #{metric_names.inspect}"
   end
 
   def test_does_not_break_when_no_verb_matches

--- a/test/new_relic/agent/agent_logger_test.rb
+++ b/test/new_relic/agent/agent_logger_test.rb
@@ -357,6 +357,32 @@ class AgentLoggerTest < Minitest::Test
     assert_logged "thoughts", "thoughts"
   end
 
+  def test_doesnt_write_log_event_aggregator
+    message = "Oops shouldn't have logged"
+    with_config(:'log_file_path' => 'stdout') do
+      NewRelic::Agent.agent.log_event_aggregator.reset!
+
+      logger = create_basic_logger
+      logger.fatal(message)
+
+      _, logs = NewRelic::Agent.agent.log_event_aggregator.harvest!
+      assert_empty logs.select { |log| log.last["message"].include?(message) }
+    end
+  end
+
+  def test_doesnt_write_log_event_aggregator_with_null_logger
+    message = "Oops shouldn't have logged"
+    with_config(:agent_enabled => false) do
+      NewRelic::Agent.agent.log_event_aggregator.reset!
+
+      logger = create_basic_logger
+      logger.fatal(message)
+
+      _, logs = NewRelic::Agent.agent.log_event_aggregator.harvest!
+      assert_empty logs.select { |log| log.last["message"].include?(message) }
+    end
+  end
+
   #
   # Helpers
   #

--- a/test/new_relic/agent/audit_logger_test.rb
+++ b/test/new_relic/agent/audit_logger_test.rb
@@ -203,6 +203,20 @@ class AuditLoggerTest < Minitest::Test
     end
   end
 
+  def test_doesnt_write_log_event_aggregator
+    with_config(:'log_file_path' => 'stdout') do
+      NewRelic::Agent.agent.log_event_aggregator.reset!
+
+      logger = NewRelic::Agent::AuditLogger.new
+      logger.log_request(@uri, @dummy_data, @marshaller)
+
+      _, logs = NewRelic::Agent.agent.log_event_aggregator.harvest!
+      audits = logs.select {|log| log.last["message"].include?("REQUEST")}
+
+      assert_empty audits
+    end
+  end
+
   def capturing_stdout
     orig = $stdout.dup
     output = ""

--- a/test/new_relic/agent/error_trace_aggregator_test.rb
+++ b/test/new_relic/agent/error_trace_aggregator_test.rb
@@ -181,14 +181,7 @@ module NewRelic
         error_trace_aggregator.notice_agent_error(DifficultToDebugAgentError.new)
         error_trace_aggregator.notice_agent_error(AnotherToughAgentError.new)
 
-        assert_metrics_recorded_exclusive([
-          'Logging/lines',
-          'Logging/lines/INFO',
-          'Logging/size',
-          'Logging/size/INFO',
-          'Supportability/API/increment_metric',
-          'Supportability/API/record_metric'
-        ])
+        assert_metrics_recorded_exclusive([])
       end
 
       def test_notice_agent_error_set_noticed_error_attributes

--- a/test/new_relic/agent/linking_metadata_test.rb
+++ b/test/new_relic/agent/linking_metadata_test.rb
@@ -1,0 +1,95 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require File.expand_path('../../../test_helper', __FILE__)
+require 'new_relic/agent/linking_metadata'
+
+module NewRelic::Agent
+  module LinkingMetadata
+    class LinkingMetadataTest < Minitest::Test
+      def setup
+        @config = nil
+        Hostname.stubs(:get).returns("localhost")
+        reset_buffers_and_caches
+      end
+
+      def teardown
+        NewRelic::Agent.config.remove_config(@config) if @config
+        NewRelic::Agent.config.reset_to_defaults
+        reset_buffers_and_caches
+      end
+
+      def test_service_metadata_requires_hash
+        assert_raises(ArgumentError) do
+          LinkingMetadata.append_service_linking_metadata(nil)
+        end
+      end
+
+      def test_service_metadata_without_guid
+        apply_config({
+          :app_name => ["Test app", "Another name"],
+        })
+
+        result = Hash.new
+        LinkingMetadata.append_service_linking_metadata(result)
+
+        expected = {
+          "entity.name" => "Test app",
+          "entity.type" => "SERVICE",
+          "hostname" => "localhost",
+        }
+        assert_equal(expected, result)
+      end
+
+      def test_service_metadata_with_guid
+        apply_config({
+          :app_name => ["Test app", "Another name"],
+          :entity_guid => "GUID"
+        })
+
+        result = Hash.new
+        LinkingMetadata.append_service_linking_metadata(result)
+
+        expected = {
+          "entity.guid" => "GUID",
+          "entity.name" => "Test app",
+          "entity.type" => "SERVICE",
+          "hostname" => "localhost",
+        }
+        assert_equal(expected, result)
+      end
+
+      def test_trace_metadata_empty
+        assert_raises(ArgumentError) do
+          LinkingMetadata.append_trace_linking_metadata(nil)
+        end
+      end
+
+      def test_trace_metadata_empty
+        result = Hash.new
+        LinkingMetadata.append_trace_linking_metadata(result)
+        assert_empty(result)
+      end
+
+      def test_trace_metadata_with_ids
+        Tracer.stubs(:current_trace_id).returns("trace_id")
+        Tracer.stubs(:current_span_id).returns("span_id")
+
+        result = Hash.new
+        LinkingMetadata.append_trace_linking_metadata(result)
+
+        expected = {
+          "trace.id" => "trace_id",
+          "span.id" => "span_id",
+        }
+        assert_equal(expected, result)
+      end
+
+      def apply_config(config)
+        @config = config
+        NewRelic::Agent.config.add_config_for_testing(@config)
+      end
+    end
+  end
+end

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -180,7 +180,7 @@ module NewRelic::Agent
     end
 
     def test_record_adds_timestamp
-      t0 = Process.clock_gettime(Process::CLOCK_REALTIME)
+      t0 = Process.clock_gettime(Process::CLOCK_REALTIME) * 1000
       message = "Time keeps slippin' away"
       @aggregator.record(message, "INFO")
 

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -1,0 +1,219 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'test_helper'))
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'data_container_tests'))
+
+require 'new_relic/agent/log_event_aggregator'
+
+module NewRelic::Agent
+  class LogEventAggregatorTest < Minitest::Test
+    def setup
+      nr_freeze_process_time
+      @aggregator = NewRelic::Agent.agent.log_event_aggregator
+      @aggregator.reset!
+
+      @enabled_config = { ENABLED_KEY => true }
+      NewRelic::Agent.config.add_config_for_testing(@enabled_config)
+
+      # Callbacks for enabled only happen on SSC addition
+      NewRelic::Agent.config.notify_server_source_added
+    end
+
+    def teardown
+      NewRelic::Agent.config.remove_config(@enabled_config)
+    end
+
+    CAPACITY_KEY = LogEventAggregator.capacity_key
+    ENABLED_KEY = LogEventAggregator.enabled_keys.first
+
+    # Helpers for DataContainerTests
+
+    def create_container
+      @aggregator
+    end
+
+    def populate_container(container, n)
+      n.times do |i|
+        container.record("A log message", ::Logger::Severity.constants.sample.to_s)
+      end
+    end
+
+    include NewRelic::DataContainerTests
+
+    def test_record_by_default_limit
+      max_samples = NewRelic::Agent.config[CAPACITY_KEY]
+      n = max_samples + 1
+      n.times do |i|
+        @aggregator.record("Take it to the limit", "FATAL")
+      end
+
+      metadata, results = @aggregator.harvest!
+      assert_equal(n, metadata[:seen])
+      assert_equal(max_samples, metadata[:capacity])
+      assert_equal(max_samples, metadata[:captured])
+      assert_equal(max_samples, results.size)
+    end
+
+    def test_record_in_transaction
+      max_samples = NewRelic::Agent.config[CAPACITY_KEY]
+      n = max_samples + 1
+      n.times do |i|
+        in_transaction do
+          @aggregator.record("Take it to the limit", "FATAL")
+        end
+      end
+
+      metadata, results = @aggregator.harvest!
+      assert_equal(n, metadata[:seen])
+      assert_equal(max_samples, metadata[:capacity])
+      assert_equal(max_samples, metadata[:captured])
+      assert_equal(max_samples, results.size)
+    end
+
+    def test_record_in_transaction_prioritizes_sampling
+      # There can be only one
+      with_config(CAPACITY_KEY => 1) do
+        in_transaction do |txn|
+          txn.sampled = false
+          @aggregator.record("Deadly", "FATAL")
+        end
+
+        in_transaction do |txn|
+          txn.sampled = true
+          @aggregator.record("Buggy", "DEBUG")
+        end
+
+        metadata, results = @aggregator.harvest!
+
+        assert_equal(2, metadata[:seen])
+        assert_equal(1, metadata[:capacity])
+        assert_equal(1, metadata[:captured])
+        assert_equal(1, results.size)
+        assert_equal("Buggy", results.first.last["message"], "Favor sampled")
+      end
+    end
+
+    def test_record_in_transaction_prioritizes_error_transactions
+      # There can be only one
+      with_config(CAPACITY_KEY => 1) do
+        in_transaction do |txn|
+          @aggregator.record("Deadly", "FATAL")
+        end
+
+        in_transaction do |txn|
+          txn.notice_error("Oops")
+          @aggregator.record("Buggy", "DEBUG")
+        end
+
+        metadata, results = @aggregator.harvest!
+
+        assert_equal(2, metadata[:seen])
+        assert_equal(1, metadata[:capacity])
+        assert_equal(1, metadata[:captured])
+        assert_equal(1, results.size)
+        assert_equal("Buggy", results.first.last["message"], "Favor errored")
+      end
+    end
+
+    def test_record_in_transaction_prioritizes_severity_when_all_else_fails
+      # There can be only one
+      with_config(CAPACITY_KEY => 1) do
+        @aggregator.record("Buggy", "DEBUG")
+        @aggregator.record("Deadly", "FATAL")
+
+        metadata, results = @aggregator.harvest!
+
+        assert_equal(2, metadata[:seen])
+        assert_equal(1, metadata[:capacity])
+        assert_equal(1, metadata[:captured])
+        assert_equal(1, results.size)
+        assert_equal("Deadly", results.first.last["message"], "Favor errored")
+      end
+    end
+
+    def test_lowering_limit_truncates_buffer
+      orig_max_samples = NewRelic::Agent.config[CAPACITY_KEY]
+
+      orig_max_samples.times do |i|
+        @aggregator.record("Truncation happens", "WARN")
+      end
+
+      new_max_samples = orig_max_samples - 10
+      with_config(CAPACITY_KEY => new_max_samples) do
+        metadata, results = @aggregator.harvest!
+        assert_equal(new_max_samples, metadata[:capacity])
+        assert_equal(orig_max_samples, metadata[:seen])
+        assert_equal(new_max_samples, results.size)
+      end
+    end
+
+    def test_record_adds_timestamp
+      t0 = Process.clock_gettime(Process::CLOCK_REALTIME)
+      message = "Time keeps slippin' away"
+      @aggregator.record(message, "INFO")
+
+      _, events = @aggregator.harvest!
+
+      assert_equal(1, events.size)
+      event = events.first
+
+      assert_equal([
+        {
+          'priority' => 1,
+        },
+        {
+          'level' => "INFO",
+          'message' => message,
+          'timestamp' => t0,
+        }
+      ],
+      event)
+    end
+
+    def test_records_metrics_on_harvest
+      with_config CAPACITY_KEY => 5 do
+        engine = NewRelic::Agent.instance.stats_engine
+        engine.reset!
+
+        9.times { @aggregator.record("Are you counting this?", "DEBUG") }
+        @aggregator.harvest!
+
+        assert_metrics_recorded_exclusive({
+          "Logging/lines" => { :call_count => 9 },
+          "Logging/lines/DEBUG" => { :call_count => 9 },
+          "Supportability/Logging/Customer/Seen" => { :call_count => 9 },
+          "Supportability/Logging/Customer/Sent" => { :call_count => 5 },
+          "Supportability/Logging/Customer/Dropped" => { :call_count => 4 },
+        },
+        :ignore_filter => %r{^Supportability/API/})
+      end
+    end
+
+
+    def test_basic_conversion_to_melt_format
+      log_data = [
+        {
+          seen: 0,
+          captured: 0,
+          linking: {
+            "entity.name": "Hola"
+          }
+        },
+        [
+          [{ "priority": 1}, { "message": "This is a mess" }]
+        ]
+      ]
+
+      payload, size = LogEventAggregator.payload_to_melt_format(log_data)
+      expected = [{
+        common: { attributes: { "entity.name": "Hola" } },
+        logs: [{"message": "This is a mess"}]
+      }]
+
+      assert_equal 1, size
+      assert_equal expected, payload
+    end
+  end
+end

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -50,9 +50,8 @@ module NewRelic::Agent
       end
 
       metadata, results = @aggregator.harvest!
-      assert_equal(n, metadata[:seen])
-      assert_equal(max_samples, metadata[:capacity])
-      assert_equal(max_samples, metadata[:captured])
+      assert_equal(n, metadata[:events_seen])
+      assert_equal(max_samples, metadata[:reservoir_size])
       assert_equal(max_samples, results.size)
     end
 
@@ -66,9 +65,8 @@ module NewRelic::Agent
       end
 
       metadata, results = @aggregator.harvest!
-      assert_equal(n, metadata[:seen])
-      assert_equal(max_samples, metadata[:capacity])
-      assert_equal(max_samples, metadata[:captured])
+      assert_equal(n, metadata[:events_seen])
+      assert_equal(max_samples, metadata[:reservoir_size])
       assert_equal(max_samples, results.size)
     end
 
@@ -87,9 +85,8 @@ module NewRelic::Agent
 
         metadata, results = @aggregator.harvest!
 
-        assert_equal(2, metadata[:seen])
-        assert_equal(1, metadata[:capacity])
-        assert_equal(1, metadata[:captured])
+        assert_equal(2, metadata[:events_seen])
+        assert_equal(1, metadata[:reservoir_size])
         assert_equal(1, results.size)
         assert_equal("Buggy", results.first.last["message"], "Favor sampled")
       end
@@ -109,9 +106,8 @@ module NewRelic::Agent
 
         metadata, results = @aggregator.harvest!
 
-        assert_equal(2, metadata[:seen])
-        assert_equal(1, metadata[:capacity])
-        assert_equal(1, metadata[:captured])
+        assert_equal(2, metadata[:events_seen])
+        assert_equal(1, metadata[:reservoir_size])
         assert_equal(1, results.size)
         assert_equal("Buggy", results.first.last["message"], "Favor errored")
       end
@@ -125,9 +121,8 @@ module NewRelic::Agent
 
         metadata, results = @aggregator.harvest!
 
-        assert_equal(2, metadata[:seen])
-        assert_equal(1, metadata[:capacity])
-        assert_equal(1, metadata[:captured])
+        assert_equal(2, metadata[:events_seen])
+        assert_equal(1, metadata[:reservoir_size])
         assert_equal(1, results.size)
         assert_equal("Deadly", results.first.last["message"], "Favor errored")
       end
@@ -143,8 +138,8 @@ module NewRelic::Agent
       new_max_samples = orig_max_samples - 10
       with_config(CAPACITY_KEY => new_max_samples) do
         metadata, results = @aggregator.harvest!
-        assert_equal(new_max_samples, metadata[:capacity])
-        assert_equal(orig_max_samples, metadata[:seen])
+        assert_equal(new_max_samples, metadata[:reservoir_size])
+        assert_equal(orig_max_samples, metadata[:events_seen])
         assert_equal(new_max_samples, results.size)
       end
     end
@@ -193,16 +188,17 @@ module NewRelic::Agent
 
 
     def test_basic_conversion_to_melt_format
+      LinkingMetadata.stubs(:append_service_linking_metadata).returns({
+        "entity.name": "Hola"
+      })
+
       log_data = [
         {
-          seen: 0,
-          captured: 0,
-          linking: {
-            "entity.name": "Hola"
-          }
+          events_seen: 0,
+          reservoir_size: 0
         },
         [
-          [{ "priority": 1}, { "message": "This is a mess" }]
+          [{ "priority": 1 }, { "message": "This is a mess" }]
         ]
       ]
 

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -243,7 +243,8 @@ module NewRelic::Agent
 
     def test_basic_conversion_to_melt_format
       LinkingMetadata.stubs(:append_service_linking_metadata).returns({
-        "entity.name": "Hola"
+        "entity.guid" => "GUID",
+        "entity.name" => "Hola",
       })
 
       log_data = [
@@ -258,7 +259,7 @@ module NewRelic::Agent
 
       payload, size = LogEventAggregator.payload_to_melt_format(log_data)
       expected = [{
-        common: { attributes: { "entity.name": "Hola" } },
+        common: { attributes: { "entity.guid" => "GUID" } },
         logs: [{"message": "This is a mess"}]
       }]
 

--- a/test/new_relic/agent/log_priority_test.rb
+++ b/test/new_relic/agent/log_priority_test.rb
@@ -1,0 +1,47 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'test_helper'))
+
+require 'new_relic/agent/log_priority'
+
+module NewRelic::Agent
+  class LogPriorityTest < Minitest::Test
+    def test_severities_only
+      assert_equal 0, LogPriority.priority_for("DEBUG")
+      assert_equal 1, LogPriority.priority_for("INFO")
+      assert_equal 2, LogPriority.priority_for("WARN")
+      assert_equal 3, LogPriority.priority_for("ERROR")
+      assert_equal 4, LogPriority.priority_for("FATAL")
+      assert_equal 5, LogPriority.priority_for("UNKNOWN")
+
+      assert_equal 0, LogPriority.priority_for("BUNK")
+      assert_equal 0, LogPriority.priority_for(nil)
+    end
+
+    def test_severity_in_transaction
+      txn = in_transaction do |txn|
+        txn.sampled = false
+        assert_equal 11, LogPriority.priority_for("INFO", txn)
+      end
+    end
+
+    def test_severity_in_error_transaction
+      txn = in_transaction do |txn|
+        txn.sampled = false
+        txn.notice_error("Boo")
+      end
+
+      assert_equal 21, LogPriority.priority_for("INFO", txn)
+    end
+
+    def test_severity_in_sampled_transaction
+      txn = in_transaction do |txn|
+        txn.sampled = true
+      end
+
+      assert_equal 111, LogPriority.priority_for("INFO", txn)
+    end
+  end
+end

--- a/test/new_relic/agent/log_priority_test.rb
+++ b/test/new_relic/agent/log_priority_test.rb
@@ -8,40 +8,15 @@ require 'new_relic/agent/log_priority'
 
 module NewRelic::Agent
   class LogPriorityTest < Minitest::Test
-    def test_severities_only
-      assert_equal 0, LogPriority.priority_for("DEBUG")
-      assert_equal 1, LogPriority.priority_for("INFO")
-      assert_equal 2, LogPriority.priority_for("WARN")
-      assert_equal 3, LogPriority.priority_for("ERROR")
-      assert_equal 4, LogPriority.priority_for("FATAL")
-      assert_equal 5, LogPriority.priority_for("UNKNOWN")
-
-      assert_equal 0, LogPriority.priority_for("BUNK")
-      assert_equal 0, LogPriority.priority_for(nil)
-    end
-
-    def test_severity_in_transaction
+    def test_uses_transaction_if_its_there
       txn = in_transaction do |txn|
-        txn.sampled = false
-        assert_equal 11, LogPriority.priority_for("INFO", txn)
+        assert_equal txn.priority, LogPriority.priority_for(txn)
       end
     end
 
-    def test_severity_in_error_transaction
-      txn = in_transaction do |txn|
-        txn.sampled = false
-        txn.notice_error("Boo")
-      end
-
-      assert_equal 21, LogPriority.priority_for("INFO", txn)
-    end
-
-    def test_severity_in_sampled_transaction
-      txn = in_transaction do |txn|
-        txn.sampled = true
-      end
-
-      assert_equal 111, LogPriority.priority_for("INFO", txn)
+    def test_random_value_if_no_transction
+      LogPriority.stubs(:rand).returns(0.1)
+      assert_equal 0.1, LogPriority.priority_for(nil)
     end
   end
 end

--- a/test/new_relic/agent/monitors/cross_app_monitor_test.rb
+++ b/test/new_relic/agent/monitors/cross_app_monitor_test.rb
@@ -161,12 +161,7 @@ module NewRelic::Agent
         'Supportability/API/drop_buffered_data',
         'OtherTransactionTotalTime',
         'OtherTransactionTotalTime/transaction',
-        'Logging/lines',
-        'Logging/lines/WARN',
-        'Logging/size',
-        'Logging/size/WARN',
         'Supportability/API/record_metric',
-        'Supportability/API/increment_metric',
         'Supportability/Deprecated/cross_application_tracer'
       ])
     end

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -461,10 +461,16 @@ class NewRelicServiceTest < Minitest::Test
     assert_equal 'some analytic events', response
   end
 
-  def error_event_data
+  def test_error_event_data
     @http_handle.respond_to(:error_event_data, 'some error events')
     response = @service.error_event_data([{}, []])
     assert_equal 'some error events', response
+  end
+
+  def test_span_event_data
+    @http_handle.respond_to(:span_event_data, 'some span events')
+    response = @service.span_event_data([{}, []])
+    assert_equal 'some span events', response
   end
 
   # Although thread profiling is only available in some circumstances, the

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -473,6 +473,12 @@ class NewRelicServiceTest < Minitest::Test
     assert_equal 'some span events', response
   end
 
+  def test_log_event_data
+    @http_handle.respond_to(:log_event_data, 'some log events')
+    response = @service.log_event_data([{}, []])
+    assert_equal 'some log events', response
+  end
+
   # Although thread profiling is only available in some circumstances, the
   # service communication doesn't care about that at all
   def test_profile_data

--- a/test/new_relic/agent/pipe_service_test.rb
+++ b/test/new_relic/agent/pipe_service_test.rb
@@ -105,6 +105,14 @@ class PipeServiceTest < Minitest::Test
       assert_equal [payload_with_newline], received_data[:transaction_sample_data]
     end
 
+    def test_log_event_data
+      payload = [{}, [[{"priority" => 1},{"message" => "yo"}]]]
+      received_data = data_from_forked_process do
+        @service.log_event_data(payload)
+      end
+      assert_equal payload, received_data[:log_event_data]
+    end
+
     def test_multiple_writes_to_pipe
       pid = Process.fork do
         metric_data0 = generate_metric_data('Custom/something')

--- a/test/new_relic/agent/transaction/segment_test.rb
+++ b/test/new_relic/agent/transaction/segment_test.rb
@@ -166,7 +166,7 @@ module NewRelic
             "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all",
             "Supportability/API/recording_web_transaction?",
             "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther",
-          ]
+          ], :ignore_filter => %r{^(Supportability/Logging|Supportability/API)}
         end
 
         def test_segment_can_disable_scoped_metric_recording_with_unscoped_as_frozen_array

--- a/test/new_relic/agent/transaction/segment_test.rb
+++ b/test/new_relic/agent/transaction/segment_test.rb
@@ -166,12 +166,6 @@ module NewRelic
             "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all",
             "Supportability/API/recording_web_transaction?",
             "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther",
-            'Logging/lines',
-            'Logging/lines/INFO',
-            'Logging/size',
-            'Logging/size/INFO',
-            'Supportability/API/increment_metric',
-            'Supportability/API/record_metric'
           ]
         end
 

--- a/test/new_relic/marshalling_test_cases.rb
+++ b/test/new_relic/marshalling_test_cases.rb
@@ -171,9 +171,11 @@ module MarshallingTestCases
     assert_equal 1, result.length
 
     common = result.first.common["attributes"]
-    refute_nil common["entity.name"]
-    refute_nil common["entity.type"]
     refute_nil common["hostname"]
+
+    # Excluding these explicitly vs classic logs-in-context to save space
+    assert_nil common["entity.name"]
+    assert_nil common["entity.type"]
 
     logs = result.first.logs
     refute_empty logs

--- a/test/new_relic/marshalling_test_cases.rb
+++ b/test/new_relic/marshalling_test_cases.rb
@@ -169,7 +169,6 @@ module MarshallingTestCases
     assert_equal 1, result.length
 
     common = result.first.common["attributes"]
-    refute_nil common["plugin.type"]
     refute_nil common["entity.name"]
     refute_nil common["entity.type"]
     refute_nil common["hostname"]

--- a/test/new_relic/marshalling_test_cases.rb
+++ b/test/new_relic/marshalling_test_cases.rb
@@ -66,7 +66,7 @@ module MarshallingTestCases
     event[0].delete("priority")
 
     assert_equal "Transaction", event[0]["type"]
-    assert_equal t0.to_f, event[0]["timestamp"]
+    assert_equal t0, event[0]["timestamp"]
     assert_equal "TestTransaction/do_it", event[0]["name"]
     assert_equal 0.0, event[0]["duration"]
     assert_equal false, event[0]["error"]
@@ -154,7 +154,9 @@ module MarshallingTestCases
   end
 
   def test_sends_log_events
-    t0 = nr_freeze_process_time
+    # Standard with other agents on millis, not seconds
+    t0 = nr_freeze_process_time.to_f * 1000
+
     message = "A deadly message"
     severity = "FATAL"
 

--- a/test/performance/suites/logging.rb
+++ b/test/performance/suites/logging.rb
@@ -22,4 +22,14 @@ class LoggingTest < Performance::TestCase
       logger.info EXAMPLE_MESSAGE
     end
   end
+
+  def test_logger_instrumentation_in_transaction
+    io = StringIO.new
+    logger = ::Logger.new io
+    measure do
+      in_transaction do
+        logger.info EXAMPLE_MESSAGE
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds prioritized, sampled log collection to the agent. There may be testing loose ends, but the bulk of the work has automated testing already at least partially in place.

This isn't targeted at the main repo's `dev` yet but the branch is usable with Bundler's git targeting if so desired.

## Story of the Changes 📖 
Because it's a lot of changes, I've staged it up to be reviewable by commit. The following will give the high level flow of the changes, and then put some comments inline to highlight points of particular interest throughout.

📈 cce02c152507f0b901fa9a7bf9db42260a2aa083 - We start off **adding performance testing** that we'll want **to baseline before/after** (specifically logging while in transactions; we had the out of transaction case already covered). If we find additional cases to compare they should get rebased back to this commit to make comparison easier.

⛓️  66cbdd38d203cbc21d5344ecca193c446c8b55ae - Logs sent from the agent need the same linking data that we use with the logs-in-context pieces, but the MELT format we'll send them in allows us to avoid repeating the values that are static (i.e. the `entity.guid`, `entity.name` and `entity.type`). To make that easier later, this change **splits out methods for getting the per-transaction linking data from the non-transaction linking data** while keeping the existing bits responding as before.

⏫  e8785fdbdcfcf8861ffbf07c8112ed8e7ca87201 - Next up because it's an easy, standalone case is we **add the logic for calculating a log event's priority**. Note that this algorithm is provisional and up for change, but also very nicely stateless in this module.

🛑 cbf64999a627a3ef1be99c25cb683da8339605ae - **Disable log capture on the `AgentLogger` and `AuditLogger`** classes within the agent. Auditing is never sensible for us to be counting or capturing at all. Agent logs may be desirable but won't be a default, and we have startup ordering issues to make that all correct (currently we only count log lines from the point when the instrumentation is installed, so we miss lots of the agent preamble). Rather than deal with these now, just shut those loggers out. 

🧺 fa8f6d6b66d9a6eb7d2670039394d7fb8259a2e9 - One of the two big pieces -- this **adds the `LogEventAggregator` which is the central class responsible for gathering up logs** until we send them during harvest. This builds off the existing event aggregators, although we do have some bits that are a little different from the others. There may be some refactoring with regards to `EventAggregator` that could happen here. In this commit the class is added, an instance _exists_ on the agent and transactions, but none of the instrumentation sends anything to the aggregator yet.

🐛 482c8918774aa7fcd72d880263615c2883559580 - In adding tests for the `NewRelicService#log_event_data` method I found **we weren't properly testing two other methods on the service** (one wrongly excluded test, one just missing). These methods also weren't making the expected response that other spots were... harmless as the main caller ignores the response, but seemed worth fixing since I was looking at it so they're all the same.

📩 e071b3cfed00a75b53a676fcceaefcb481473ab2 - **Adds the `log_event_data` methods to our services for transmitting** log payloads to the Collector. Note that because of Resque (and maybe other forked processes?) anything that gets on the `NewRelicService` for talking to the Collector _also_ needs to go on the `PipeService` (for talking from a forked process back to the parent process that will talk to NR). These are added, briefly tested but not wired into harvest at this point.

🔑 8f2b888ecd537e38ebb38f05623f2bf11216baf2 - **Adds default for our current (sure to be wrongly named) config keys**. Tests before this were all updated to not assume a given default value. Tests after this may break if we change default to off, but that'll show up immediately.

🎺  74f5684f53132521badb68df23d1e4e4cc4b5e7a - **Instrumentation on `Logger` now hands log events to the aggregator**. The aggregator also takes care now of our metric recording (which we do in batch on each attempted harvest vs every log line which has a huge performance benefit with little downside since even when the aggregator is disabled, the harvest loop still asks each time).

🍞  3b53a190a2327d40d690cdf49909e2e5e7a19c1f - Last and certainly not least, we **wire the aggregator in to send data on each harvest cycle**. The shape of this payload is slightly different than other payloads before but that's mostly isolated in the aggregator.

## Testing 🔬 

Obviously a big consideration on this is the overhead and establishing what reasonable limits are.

Internally there's a test app called log-jam which I've been running these changes on repeatedly as they're under development. This was tested disabling instrumentation, just taking metrics, and with a log buffer of 1000, 2000 and 5000 logs-per-minute. Since the links are all internal I won't put it here, but we may discuss results in the real PR to the main repo.

I'm planning to also get this running on other apps as soon as possible to see real-world impact, as the test app basically _just_ logs, so it's not really representative.